### PR TITLE
Use branch prefix when not updating to latest

### DIFF
--- a/src/CosyComposer.php
+++ b/src/CosyComposer.php
@@ -1414,7 +1414,8 @@ class CosyComposer
                     $new_branch_name = $this->createBranchNameFromVersions(
                         $item->name,
                         $item->version,
-                        $post_update_data->version
+                        $post_update_data->version,
+                        $config
                     );
                     $this->log('Changing branch because of an unexpected update result: ' . $branch_name);
                     $this->execCommand('git checkout -b ' . $new_branch_name, false);
@@ -1673,21 +1674,20 @@ class CosyComposer
             }
             return sprintf('%sviolinist%s', $prefix, $this->createBranchNameFromVersions($item->name, '', ''));
         }
-        $name = $this->createBranchNameFromVersions($item->name, $item->version, $item->latest);
+        return $this->createBranchNameFromVersions($item->name, $item->version, $item->latest, $config);
+    }
+
+    protected function createBranchNameFromVersions($package, $version_from, $version_to, $config = null)
+    {
+        $item_string = sprintf('%s%s%s', $package, $version_from, $version_to);
+        // @todo: Fix this properly.
+        $result = preg_replace('/[^a-zA-Z0-9]+/', '', $item_string);
         $prefix = '';
         if ($config) {
             /** @var Config $config */
             $prefix = $config->getBranchPrefix();
         }
-        return "$prefix$name";
-    }
-
-    protected function createBranchNameFromVersions($package, $version_from, $version_to)
-    {
-        $item_string = sprintf('%s%s%s', $package, $version_from, $version_to);
-        // @todo: Fix this properly.
-        $result = preg_replace('/[^a-zA-Z0-9]+/', '', $item_string);
-        return $result;
+        return $prefix.$result;
     }
 
     /**

--- a/test/integration/BranchPrefixTest.php
+++ b/test/integration/BranchPrefixTest.php
@@ -28,4 +28,13 @@ class BranchPrefixTest extends ComposerUpdateIntegrationBase
         $this->runtestExpectedOutput();
         self::assertEquals('my_prefixpsrlog100114', $this->prParams["head"]);
     }
+
+    public function testBranchPrefixUsedNotLatest()
+    {
+        // Set latest version to be newer than the updated version
+        $this->packageVersionForToUpdateOutput = '1.2.4';
+        $this->setUp();
+        $this->runtestExpectedOutput();
+        self::assertEquals('my_prefixpsrlog100114', $this->prParams["head"]);
+    }
 }


### PR DESCRIPTION
The branch prefix was not being used when the updated version was not the latest version.

