### PR TITLE
Remove the temp parent logic as its not needed any more

### DIFF
--- a/src/CosyComposer.php
+++ b/src/CosyComposer.php
@@ -136,11 +136,6 @@ class CosyComposer
     protected $composerJsonDir;
 
     /**
-     * @var string
-     */
-    protected $tmpParent = '/tmp';
-
-    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -269,22 +264,6 @@ class CosyComposer
     public function setHttpClient(HttpClient $httpClient)
     {
         $this->httpClient = $httpClient;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTmpParent()
-    {
-        return $this->tmpParent;
-    }
-
-    /**
-     * @param string $tmpParent
-     */
-    public function setTmpParent($tmpParent)
-    {
-        $this->tmpParent = $tmpParent;
     }
 
     /**
@@ -569,11 +548,6 @@ class CosyComposer
         $this->log(sprintf('Starting update check for %s', $this->slug->getSlug()));
         $user_name = $this->slug->getUserName();
         $user_repo = $this->slug->getUserRepo();
-        // First set working dir to /tmp (since we might be in the directory of the
-        // last processed item, which may be deleted.
-        if (!$this->chdir($this->getTmpParent())) {
-            throw new ChdirException('Problem with changing dir to ' . $this->getTmpParent());
-        }
         $hostname = $this->slug->getProvider();
         $url = null;
         // Make sure we accept the fingerprint of whatever we are cloning.

--- a/test/integration/FailTest.php
+++ b/test/integration/FailTest.php
@@ -9,15 +9,6 @@ use eiriksm\CosyComposer\Exceptions\ChdirException;
 class FailTest extends Base
 {
 
-    public function testChdirFail()
-    {
-        $c = $this->getMockCosy();
-        $c->setTmpParent('/stupid/nonexistent');
-        $this->expectException(ChdirException::class);
-        $this->expectExceptionMessage('Problem with changing dir to /stupid/nonexistent');
-        $c->run();
-    }
-
     public function testGitFail()
     {
         $c = $this->getMockCosy();


### PR DESCRIPTION
This was probably a relic from back in the day when this script was run as part of a loop, and processed things in folders, and then deleted them when it was done.

I don't see how we need it now or in the future any more. Also, all processes should use the process component, which would take care of working directories by itself, and probably not even use this